### PR TITLE
feat: Auto-feed Username after github login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+GITHUB_CLIENT_ID=your-github-client-id
+GITHUB_CLIENT_SECRET=your-github-client-secret
+OPENAI_API_KEY_NEW4=your-openai-api-key

--- a/public/app.js
+++ b/public/app.js
@@ -1,11 +1,8 @@
 let username = ''
 document.addEventListener('DOMContentLoaded', () => {
-  fetch(window.location.href)
-    .then(response => {
-      username = response.headers.get('GITHUB_USERNAME');
-      console.log("Roasting: ", username)
-      document.getElementById('username').value = username;
-    });
+  var params = new URLSearchParams(window.location.search);
+  username = params.get("username");
+  document.getElementById("username").value = username;
 });
 
 async function getRoast() {

--- a/public/app.js
+++ b/public/app.js
@@ -1,7 +1,17 @@
+let username = ''
+document.addEventListener('DOMContentLoaded', () => {
+  fetch(window.location.href)
+    .then(response => {
+      username = response.headers.get('GITHUB_USERNAME');
+      console.log("Roasting: ", username)
+      document.getElementById('username').value = username;
+    });
+});
+
 async function getRoast() {
-  const username = document.getElementById("username").value;
+
   if (!username) {
-    alert("Please enter a GitHub username.");
+    alert("Something seems wrong, try re-logging or entering username again.");
     return;
   }
 

--- a/server.js
+++ b/server.js
@@ -52,12 +52,7 @@ app.get('/auth/github/callback',
 // Protected route to serve the homepage after login
 app.get('/home', (req, res) => {
     if (req.isAuthenticated()) {
-        const {username} = req.query;
-        res.sendFile(path.join(__dirname, 'public', 'home.html'), {
-            headers: {
-                'GITHUB_USERNAME': username
-            }
-        });
+        res.sendFile(path.join(__dirname, 'public', 'home.html'));
     } else {
         res.redirect('/');
     }

--- a/server.js
+++ b/server.js
@@ -44,12 +44,20 @@ app.get('/auth/github', passport.authenticate('github'));
 // GitHub callback route
 app.get('/auth/github/callback', 
     passport.authenticate('github', { failureRedirect: '/' }),
-    (req, res) => res.redirect('/home'));
+    (req, res) => {
+        const username =  req.user.username;
+        res.redirect(`/home?username=${username}`)
+    });
 
 // Protected route to serve the homepage after login
 app.get('/home', (req, res) => {
     if (req.isAuthenticated()) {
-        res.sendFile(path.join(__dirname, 'public', 'home.html'));
+        const {username} = req.query;
+        res.sendFile(path.join(__dirname, 'public', 'home.html'), {
+            headers: {
+                'GITHUB_USERNAME': username
+            }
+        });
     } else {
         res.redirect('/');
     }
@@ -92,12 +100,3 @@ app.get('/roast/:username', async (req, res) => {
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Server is running on http://localhost:${PORT}`));
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Hey Haimantika,
Super cool project 🤩 . Saw a response on your tweet by [Prateek](https://x.com/kitarp29/status/1858581718216962253) and wanted to contribute that feature here. For now, I am just extracting the username and feeding it into the input box so the user doesn't have to feed theirs but still have options to check roasts for others (if that is the feature you have provided) I still wanted to give users the option to be able to add new username. 
Let me know if you want to totally bypass the input section tho.

![Screenshot 2024-11-20 at 2 00 12 PM](https://github.com/user-attachments/assets/c1680cf9-e919-4a7c-b5d0-82183c7a92a1)

## Known bug 🐛 

- If you try to revert back to `/` endpoint after login, it will redirect you to home but since there is no parameter in request that has user value it shows the following (Maybe new contribution can fix this with new issue 😅 )
- I might have missed some edge cases coz I focused on only one feature for quick contribution here.

![Screenshot 2024-11-20 at 1 59 22 PM](https://github.com/user-attachments/assets/25c9c3c7-95d6-4a1f-b585-6f51ff1ce96b)

## Suggestions 💡 

- I have not added it here coz it will add a task on your end and I really didn't want that but it could be good idea to also store `callbackURL` in environment variable for easy local development.
- I have added `.example.env` so anyone can quickly setup local environment for testing the project.
